### PR TITLE
Fix broken globs in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,12 +53,12 @@ Options
 Command ``build_grpc`` provides following options:
 
 * ``proto_files``: Newline separated list of glob patterns matching protobuf files to be compiled.
-  Paths are relative to the current directory.
+  Paths are relative to `proto_path`.
   ``**`` can be used to match any files and zero or more directories.
   Default value is empty list.
 
 * ``grpc_files``: Newline separated list of glob patterns matching grpc service files to be compiled.
-  Paths are relative to the current directory.
+  Paths are relative to `proto_path`.
   ``**`` can be used to match any files and zero or more directories.
   Default value is empty list.
 
@@ -112,7 +112,7 @@ otherwise ``setuptools_grpc`` won't do anything.
 
    # file: setup.cfg
    [build_grpc]
-   proto_files = src/**/*.proto
-   grpc_files = src/**/*_grpc.proto
+   proto_files = **/*.proto
+   grpc_files = **/*_grpc.proto
    proto_path = ./src
    output_path = ./out


### PR DESCRIPTION
I was trying to follow the README, and found that these globs weren't actually matching any files, because [they get prefixed with `proto_path`](https://github.com/CZ-NIC/setuptools-grpc/blob/0.5/setuptools_grpc/build_grpc.py#L43), so we were ending up with a glob that looked something like `./src/src/*.proto` (which I assume was not the intent here).