### PR TITLE
Drop pkg_resources

### DIFF
--- a/setuptools_grpc/build_grpc.py
+++ b/setuptools_grpc/build_grpc.py
@@ -5,7 +5,6 @@ from distutils import log
 from glob import glob
 from pathlib import Path
 
-import pkg_resources
 from grpc_tools.protoc import main as protoc_main
 from setuptools import Command
 
@@ -65,9 +64,7 @@ class build_grpc(Command):
 
         Call `protoc` command to compile protobuf and grpc source files to python modules.
         """
-        includes = (self.proto_path, pkg_resources.resource_filename("grpc_tools", "_proto"))
-        args = ["__main__"]
-        args.extend("-I%s" % x for x in includes)
+        args = ["__main__", "-I{}".format(self.proto_path)]
 
         # Generate protobuf modules
         if self.proto_files:

--- a/tests/test_build_grpc.py
+++ b/tests/test_build_grpc.py
@@ -1,4 +1,4 @@
-from unittest.mock import ANY, call, patch
+from unittest.mock import call, patch
 
 import pytest
 from setuptools import Distribution
@@ -72,7 +72,6 @@ def test_run(tmpdir):
                 [
                     "__main__",
                     "-I" + tmpdir.path + "/src",
-                    ANY,
                     "--python_out",
                     tmpdir.path + "/dest",
                     "--pyi_out",
@@ -86,7 +85,6 @@ def test_run(tmpdir):
                 [
                     "__main__",
                     "-I" + tmpdir.path + "/src",
-                    ANY,
                     "--grpc_python_out",
                     tmpdir.path + "/dest",
                     tmpdir.path + "/src/services/service_grpc.proto",


### PR DESCRIPTION
`pkg_resources` are deprecated and should be no longer used. See https://setuptools.pypa.io/en/latest/pkg_resources.html for further info.

It seems that explicitly including `google.protobuf` path hasn't been required for ages and is not required by the minimum version of `grpcio-tools` required by `setuptools-grpc`. Therefore, I'm just dropping the whole thing.